### PR TITLE
Support multiple bot wallets

### DIFF
--- a/next-sniper/src/utils/botWalletManager.ts
+++ b/next-sniper/src/utils/botWalletManager.ts
@@ -11,42 +11,63 @@ export function generateBotWallet(): Keypair {
     return keypair;
 }
 
-export async function saveBotWallet(network: NetworkType, keypair: Keypair): Promise<void> {
+// Utilities for a single wallet are kept for backwards compatibility but the new
+// implementation focuses on handling multiple wallets.  The storage key now uses
+// the plural form `bot-wallets-${network}`.
+
+export function generateBotWallets(count: number): Keypair[] {
+    return Array.from({ length: count }, () => generateBotWallet());
+}
+
+export async function saveBotWallets(network: NetworkType, keypairs: Keypair[]): Promise<void> {
     try {
-        const secretKey = keypair.secretKey;
         const password = getEncryptionPassword();
-        const encryptedKey = secretKey.map((byte, index) => byte ^ password.charCodeAt(index % password.length));
-        
-        const keyToSave = JSON.stringify(Array.from(encryptedKey));
-        localStorage.setItem(`bot-wallet-${network}`, keyToSave);
-        console.log(`[BotWalletManager] Saved bot wallet for ${network} to localStorage.`);
+        const encryptedKeys = keypairs.map(kp => {
+            return Array.from(kp.secretKey).map((byte, idx) => byte ^ password.charCodeAt(idx % password.length));
+        });
+        localStorage.setItem(`bot-wallets-${network}`, JSON.stringify(encryptedKeys));
+        console.log(`[BotWalletManager] Saved ${keypairs.length} bot wallet(s) for ${network} to localStorage.`);
     } catch (error) {
-        console.error(`[BotWalletManager] Failed to save wallet for ${network}:`, error);
-        throw new Error("Failed to save bot wallet.");
+        console.error(`[BotWalletManager] Failed to save wallets for ${network}:`, error);
+        throw new Error('Failed to save bot wallets.');
     }
+}
+
+export function loadBotWallets(network: NetworkType): Keypair[] {
+    try {
+        const stored = localStorage.getItem(`bot-wallets-${network}`);
+        if (!stored) return [];
+        const encrypted: number[][] = JSON.parse(stored);
+        const password = getEncryptionPassword();
+        const wallets = encrypted.map(arr => {
+            const decrypted = arr.map((byte, idx) => byte ^ password.charCodeAt(idx % password.length));
+            const secretKey = new Uint8Array(decrypted);
+            return Keypair.fromSecretKey(secretKey);
+        });
+        console.log(`[BotWalletManager] Loaded ${wallets.length} bot wallet(s) for ${network}.`);
+        return wallets;
+    } catch (error) {
+        console.error(`[BotWalletManager] Failed to load wallets for ${network}:`, error);
+        clearBotWallets(network);
+        return [];
+    }
+}
+
+export function clearBotWallets(network: NetworkType): void {
+    localStorage.removeItem(`bot-wallets-${network}`);
+    console.log(`[BotWalletManager] Cleared bot wallets for ${network}.`);
+}
+
+// Deprecated single-wallet helpers for compatibility with older components.
+export async function saveBotWallet(network: NetworkType, keypair: Keypair): Promise<void> {
+    await saveBotWallets(network, [keypair]);
 }
 
 export function loadBotWallet(network: NetworkType): Keypair | null {
-    try {
-        const storedKey = localStorage.getItem(`bot-wallet-${network}`);
-        if (!storedKey) {
-            return null;
-        }
-        const encryptedKeyArray = JSON.parse(storedKey) as number[];
-        const password = getEncryptionPassword();
-        const decryptedKeyArray = encryptedKeyArray.map((byte, index) => byte ^ password.charCodeAt(index % password.length));
-        const secretKey = new Uint8Array(decryptedKeyArray);
-        const keypair = Keypair.fromSecretKey(secretKey);
-        console.log(`[BotWalletManager] Loaded bot wallet for ${network}: ${keypair.publicKey.toBase58()}`);
-        return keypair;
-    } catch (error) {
-        console.error(`[BotWalletManager] Failed to load or decrypt wallet for ${network}:`, error);
-        clearBotWallet(network);
-        return null;
-    }
+    const wallets = loadBotWallets(network);
+    return wallets[0] ?? null;
 }
 
 export function clearBotWallet(network: NetworkType): void {
-    localStorage.removeItem(`bot-wallet-${network}`);
-    console.log(`[BotWalletManager] Cleared bot wallet for ${network}.`);
+    clearBotWallets(network);
 }


### PR DESCRIPTION
## Summary
- extend bot wallet manager to handle multiple wallets
- allow BotManager to manage an array of wallets and render a bot for each

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: many missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ff497d9ac83279ee79474b28e4fd7